### PR TITLE
Make issue title and label configurable 

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -6,6 +6,16 @@ inputs:
     description: >-
       The path to the log file
     required: true
+  issue-title:
+    description: >-
+      Title of issue being created or updated
+    required: false
+    default: "⚠️ Nightly upstream-dev CI failed ⚠️"
+  issue-label:
+    description: >-
+      Labels to apply to issue
+    required: false
+    default: "CI"
 outputs: {}
 branding:
   color: 'red'
@@ -30,7 +40,7 @@ runs:
         script: |
           const fs = require('fs');
           const pytest_logs = fs.readFileSync('pytest-logs.txt', 'utf8');
-          const title = "⚠️ Nightly upstream-dev CI failed ⚠️"
+          const title = ${{ inputs.issue-title }}
           const workflow_url = `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
           const issue_body = `[Workflow Run URL](${workflow_url})\n${pytest_logs}`
 
@@ -52,7 +62,7 @@ runs:
           const variables = {
             owner: context.repo.owner,
             name: context.repo.repo,
-            label: 'CI',
+            label: ${{ inputs.issue-label }},
             creator: "github-actions[bot]"
           }
           const result = await github.graphql(query, variables)

--- a/action.yaml
+++ b/action.yaml
@@ -40,7 +40,7 @@ runs:
         script: |
           const fs = require('fs');
           const pytest_logs = fs.readFileSync('pytest-logs.txt', 'utf8');
-          const title = ${{ inputs.issue-title }}
+          const title = "${{ inputs.issue-title }}"
           const workflow_url = `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
           const issue_body = `[Workflow Run URL](${workflow_url})\n${pytest_logs}`
 
@@ -62,7 +62,7 @@ runs:
           const variables = {
             owner: context.repo.owner,
             name: context.repo.repo,
-            label: ${{ inputs.issue-label }},
+            label: "${{ inputs.issue-label }}",
             creator: "github-actions[bot]"
           }
           const result = await github.graphql(query, variables)


### PR DESCRIPTION
Dask has a very similar `upstream` CI build to `xarray`s. I stumbled across this action and would love to use it over in `dask/dask`. However, we use a different label for upstream CI failures (`upstream` instead of `CI`). We also (currently) use a different name for the issues that get opened, though this isn't a huge deal. 

This PR proposes we make the issue title and label configurable, defaulting to what's currently being used. @keewis does this seem reasonable to you? 

I'm trying out the changes in this PR over in this [this branch](https://github.com/jrbourbeau/dask/commits/update-upstream-ci) of my `dask` fork and things appear to be working as expected and opened this issue https://github.com/jrbourbeau/dask/issues/3. 