### PR TITLE
use a login shell for shell code steps

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -26,16 +26,16 @@ runs:
   # TODO: learn enough javascript / node.js to write the reportlog parsing
   steps:
     - name: print environment information
-      shell: bash
+      shell: bash -l {0}
       run: |
         python --version
         python -m pip list
     - name: install dependencies
-      shell: bash
+      shell: bash -l {0}
       run: |
         python -m pip install pytest more-itertools
     - name: produce the issue body
-      shell: bash
+      shell: bash -l {0}
       run: |
         python $GITHUB_ACTION_PATH/parse_logs.py ${{ inputs.log-path }}
     - name: create the issue


### PR DESCRIPTION
The python environments created by the `conda` actions require login shells. `actions/setup-python` doesn't, but it will work regardless.