### PR TITLE
fix strict xpass

### DIFF
--- a/parse_logs.py
+++ b/parse_logs.py
@@ -86,7 +86,10 @@ def preformat_report(report):
 @preformat_report.register
 def _(report: TestReport):
     parsed = parse_nodeid(report.nodeid)
-    message = report.longrepr.chain[0][1].message
+    if isinstance(report.longrepr, str):
+        message = report.longrepr
+    else:
+        message = report.longrepr.chain[0][1].message
     return PreformattedReport(message=message, **parsed)
 
 


### PR DESCRIPTION
As it turns out, `XPASS`ing tests become failures with `xfail_strict = true`, but with the `xfail` reason as the `longrepr`. This caused the parser script to choke, because it violates the current assumption that `longrepr` is a chain object (which usually also contains a traceback).

The fix is to just use `longrepr` as the error message if it is already a string.

xref dask/dask#9818, cc @jrbourbeau