### PR TITLE
properly parse and format the `nodeid` of errored test modules

### DIFF
--- a/parse_logs.py
+++ b/parse_logs.py
@@ -117,8 +117,10 @@ def _(report: CollectReport):
 def format_summary(report):
     if report.variant is not None:
         return f"{report.filepath}::{report.name}[{report.variant}]: {report.message}"
-    else:
+    elif report.name is not None:
         return f"{report.filepath}::{report.name}: {report.message}"
+    else:
+        return f"{report.filepath}: {report.message}"
 
 
 def format_report(summaries, py_version):

--- a/parse_logs.py
+++ b/parse_logs.py
@@ -98,8 +98,19 @@ def _(report: CollectReport):
     if report.nodeid == "":
         return CollectionError(name=test_collection_stage, repr_=str(report.longrepr))
 
-    parsed = parse_nodeid(report.nodeid)
-    message = report.longrepr.split("\n")[-1].removeprefix("E").lstrip()
+    if "::" not in report.nodeid:
+        parsed = {
+            "filepath": report.nodeid,
+            "name": None,
+            "variant": None,
+        }
+    else:
+        parsed = parse_nodeid(report.nodeid)
+
+    if isinstance(report.longrepr, str):
+        message = report.longrepr.split("\n")[-1].removeprefix("E").lstrip()
+    else:
+        message = report.longrepr.chain[0][1].message
     return PreformattedReport(message=message, **parsed)
 
 


### PR DESCRIPTION
- [x] closes #14

Errored test modules (modules that raise an error on import) seem to have a `nodeid` containing just the path. The parsing function assumed otherwise, so it failed.

@jrbourbeau, I think this fixes #14, but I can't reproduce the error from the CI locally so I can't verify. The error from the script does look very similar to the one produced by a test module containing just 
```python
raise ValueError
```
though, so I'm pretty confident it does (and if I'm wrong we can just iterate).