### PR TITLE
allow assigning users to the newly-created issues

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -16,6 +16,11 @@ inputs:
       Labels to apply to issue
     required: false
     default: "CI"
+  assignees:
+    description: >-
+      Users to assign to the issue
+    required: false
+    default: []
 outputs: {}
 branding:
   color: "red"
@@ -80,7 +85,8 @@ runs:
               repo: variables.name,
               body: issue_body,
               title: title,
-              labels: [variables.label]
+              labels: [variables.label],
+              assignees: ${{ inputs.assignees }}
             })
           } else {
             github.rest.issues.update({

--- a/action.yaml
+++ b/action.yaml
@@ -18,9 +18,9 @@ inputs:
     default: "CI"
   assignees:
     description: >-
-      Users to assign to the issue
+      Comma-separated users to assign to the issue.
     required: false
-    default: []
+    default: ""
 outputs: {}
 branding:
   color: "red"
@@ -86,7 +86,7 @@ runs:
               body: issue_body,
               title: title,
               labels: [variables.label],
-              assignees: ${{ inputs.assignees }}
+              assignees: ${{ inputs.assignees.split(',') }}
             })
           } else {
             github.rest.issues.update({

--- a/action.yaml
+++ b/action.yaml
@@ -86,7 +86,7 @@ runs:
               body: issue_body,
               title: title,
               labels: [variables.label],
-              assignees: ${{ inputs.assignees.split(',') }}
+              assignees: ${{ inputs.assignees }}.split(',')
             })
           } else {
             github.rest.issues.update({

--- a/action.yaml
+++ b/action.yaml
@@ -51,6 +51,7 @@ runs:
           const fs = require('fs');
           const pytest_logs = fs.readFileSync('pytest-logs.txt', 'utf8');
           const title = "${{ inputs.issue-title }}"
+          const assignees = "${{inputs.assignees}}".split(",")
           const workflow_url = `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
           const issue_body = `[Workflow Run URL](${workflow_url})\n${pytest_logs}`
 
@@ -86,7 +87,7 @@ runs:
               body: issue_body,
               title: title,
               labels: [variables.label],
-              assignees: ${{ inputs.assignees }}.split(',')
+              assignees: assignees
             })
           } else {
             github.rest.issues.update({


### PR DESCRIPTION
This implements the feature requested in https://github.com/xarray-contrib/issue-from-pytest-log/issues/2#issuecomment-1483011124 (cc @Zeitsperre).

See keewis/reportlog-test#7 for an example. Works for no assignees (empty string, the default) and a single user only so far. Multiple users fails with a ["Validation Failed"](https://github.com/keewis/reportlog-test/actions/runs/7100253993/job/19325949588) error, not sure if that has anything to do with the second user I tried not having push rights.