### PR TITLE
Modify GraphQL query to uniquely identify issues

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -51,20 +51,22 @@ runs:
         script: |
           const fs = require('fs');
           const pytest_logs = fs.readFileSync('pytest-logs.txt', 'utf8');
-          const title = "${{ inputs.issue-title }}"
-          const assignees = "${{inputs.assignees}}".split(",")
-          const workflow_url = `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
-          const issue_body = `[Workflow Run URL](${workflow_url})\n${pytest_logs}`
+          const title = "${{ inputs.issue-title }}";
+          const assignees = "${{inputs.assignees}}".split(",");
+          const workflow_url = `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+          const issue_body = `[Workflow Run URL](${workflow_url})\n${pytest_logs}`;
 
           // Run GraphQL query against GitHub API to find the most recent open issue used for reporting failures
+          // This finds the issue based on the title, so if that changes, a new issue will be created.
           const query = `query($owner:String!, $name:String!, $creator:String!, $label:String!){
             repository(owner: $owner, name: $name) {
-              issues(first: 1, states: OPEN, filterBy: {createdBy: $creator, labels: [$label]}, orderBy: {field: CREATED_AT, direction: DESC}) {
+              issues(first: 100, states: OPEN, filterBy: {createdBy: $creator, labels: [$label]}, orderBy: {field: CREATED_AT, direction: DESC}) {
                 edges {
                   node {
                     body
                     id
                     number
+                    title
                   }
                 }
               }
@@ -76,12 +78,14 @@ runs:
             name: context.repo.repo,
             label: "${{ inputs.issue-label }}",
             creator: "github-actions[bot]"
-          }
-          const result = await github.graphql(query, variables)
+          };
 
-          // If no issue is open, create a new issue,
-          // else update the body of the existing issue.
-          if (result.repository.issues.edges.length === 0) {
+          const result = await github.graphql(query, variables);
+          let existingIssue = result.repository.issues.edges.find(edge => edge.node.title === title);
+
+          // If no issue is found to be open, or if found issue's title doesn't match,
+          // then we create a new issue. Else, we update the body of the existing issue.
+          if (!existingIssue) {
             github.rest.issues.create({
               owner: variables.owner,
               repo: variables.name,
@@ -89,12 +93,13 @@ runs:
               title: title,
               labels: [variables.label],
               assignees: assignees
-            })
+            });
           } else {
+            // Update the body of the existing issue
             github.rest.issues.update({
               owner: variables.owner,
               repo: variables.name,
-              issue_number: result.repository.issues.edges[0].node.number,
+              issue_number: existingIssue.node.number,
               body: issue_body
-            })
+            });
           }


### PR DESCRIPTION
## Description

This PR updates the GraphQL search query currently being run against the GitHub API to look not just for issues by a particular creator but also to match the title in the search query.

This allows for the use of GitHub Actions variables and contexts coming from matrices or job IDs or similar in the issue, such as

```yaml
issue-title: "${{ matrix.os }} did not pass"
```

and therefore allow the creation of and updates to issues based on these custom issue titles, and prevent updating the body of a singular issue if multiple jobs (or matrices) are being used to create issues.

## What issue does this PR address?

Closes #34

## Additional context

The changes can be verified in workflow runs and through the issues opened by the action on my fork, here: https://github.com/agriyakhetarpal/issue-from-pytest-log/pull/1, displaying that the proposed changes are working as usual.