### PR TITLE
allow parametrizing the issue title

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ In case you don't like the default title for new issues, this setting can be use
     issue-title: "Nightly CI failed"
 ```
 
+The title can also be parametrized, in which case a separate issue will be opened for each variation of the title.
+
 ### issue label
 
 optional. Default: `CI`

--- a/action.yaml
+++ b/action.yaml
@@ -79,7 +79,7 @@ runs:
             creator: "app/github-actions",
             title: "${{ inputs.issue-title }}"
           }
-          const result = await github.graphql(query, variables)
+          const result = await github.graphql(query, variables);
 
           // If no issue is open, create a new issue,
           // else update the body of the existing issue.
@@ -91,12 +91,12 @@ runs:
               title: title,
               labels: [label],
               assignees: assignees
-            })
+            });
           } else {
             github.rest.issues.update({
               owner: owner,
               repo: name,
               issue_number: result.search.edges[0].node.number,
               body: issue_body
-            })
+            });
           }

--- a/action.yaml
+++ b/action.yaml
@@ -82,20 +82,20 @@ runs:
 
           // If no issue is open, create a new issue,
           // else update the body of the existing issue.
-          if (result.repository.issues.edges.length === 0) {
+          if (result.search.edges.length === 0) {
             github.rest.issues.create({
-              owner: variables.owner,
-              repo: variables.name,
+              owner: owner,
+              repo: name,
               body: issue_body,
               title: title,
-              labels: [variables.label],
+              labels: [label],
               assignees: assignees
             })
           } else {
             github.rest.issues.update({
-              owner: variables.owner,
-              repo: variables.name,
-              issue_number: result.repository.issues.edges[0].node.number,
+              owner: owner,
+              repo: name,
+              issue_number: result.search.edges[0].node.number,
               body: issue_body
             })
           }

--- a/action.yaml
+++ b/action.yaml
@@ -75,6 +75,7 @@ runs:
             owner: context.repo.owner,
             name: context.repo.repo,
             label: "${{ inputs.issue-label }}",
+            title: "${{ inputs.issue-title }}",
             creator: "github-actions[bot]"
           }
           const result = await github.graphql(query, variables)

--- a/action.yaml
+++ b/action.yaml
@@ -52,7 +52,6 @@ runs:
         script: |
           const fs = require('fs');
           const pytest_logs = fs.readFileSync('pytest-logs.txt', 'utf8');
-          const title = "${{ inputs.issue-title }}";
           const assignees = "${{inputs.assignees}}".split(",");
           const workflow_url = `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
           const issue_body = `[Workflow Run URL](${workflow_url})\n${pytest_logs}`;
@@ -85,17 +84,17 @@ runs:
           // else update the body of the existing issue.
           if (result.search.edges.length === 0) {
             github.rest.issues.create({
-              owner: owner,
-              repo: name,
+              owner: variables.owner,
+              repo: variables.name,
               body: issue_body,
-              title: title,
-              labels: [label],
+              title: variables.title,
+              labels: [variables.label],
               assignees: assignees
             });
           } else {
             github.rest.issues.update({
-              owner: owner,
-              repo: name,
+              owner: variables.owner,
+              repo: variables.name,
               issue_number: result.search.edges[0].node.number,
               body: issue_body
             });

--- a/action.yaml
+++ b/action.yaml
@@ -57,9 +57,9 @@ runs:
           const issue_body = `[Workflow Run URL](${workflow_url})\n${pytest_logs}`
 
           // Run GraphQL query against GitHub API to find the most recent open issue used for reporting failures
-          const query = `query($owner:String!, $name:String!, $creator:String!, $title:String!, $label:String!){
+          const query = `query($value:String!) {
             query {
-              search(query: $query, type:ISSUE, first: 1) {
+              search(query: $value, type:ISSUE, first: 1) {
                 edges {
                   node {
                     ... on Issue {
@@ -78,7 +78,7 @@ runs:
           const creator = "app/github-actions";
 
           const variables = {
-            query: `repo:${owner}/${name} author:${creator} label:${label} is:open in:title ${title}`
+            value: `repo:${owner}/${name} author:${creator} label:${label} is:open in:title ${title}`
           }
           const result = await github.graphql(query, variables)
 

--- a/action.yaml
+++ b/action.yaml
@@ -58,7 +58,7 @@ runs:
 
           // Run GraphQL query against GitHub API to find the most recent open issue used for reporting failures
           const query = `query($owner:String!, $name:String!, $creator:String!, $label:String!, $title:String!) {
-            search(query: "repo:${owner}/${name} author:${creator} label:${label} is:open in:title ${title}", type:ISSUE, first: 1) {
+            search(query: "repo:$owner/$name author:$creator label:$label is:open in:title $title", type:ISSUE, first: 1) {
               edges {
                 node {
                   ... on Issue {

--- a/action.yaml
+++ b/action.yaml
@@ -58,8 +58,8 @@ runs:
           const issue_body = `[Workflow Run URL](${workflow_url})\n${pytest_logs}`;
 
           // Run GraphQL query against GitHub API to find the most recent open issue used for reporting failures
-          const query = `query($value:String!) {
-            search(query: $value, type:ISSUE, first: 1) {
+          const query = `query($owner:String!, $name:String!, $creator:String!, $label:String!, $title:String!) {
+            search(query: "repo:${owner}/${name} author:${creator} label:${label} is:open in:title ${title}", type:ISSUE, first: 1) {
               edges {
                 node {
                   ... on Issue {
@@ -71,13 +71,13 @@ runs:
               }
             }
           }`;
-          const owner = context.repo.owner;
-          const name = context.repo.repo;
-          const label = "${{ inputs.issue-label }}";
-          const creator = "app/github-actions";
 
           const variables = {
-            value: `repo:${owner}/${name} author:${creator} label:${label} is:open in:title ${title}`
+            owner: context.repo.owner,
+            name: context.repo.repo,
+            label: "${{ inputs.issue-label }}";
+            creator: "app/github-actions",
+            title: "${{ inputs.issue-title }}"
           }
           const result = await github.graphql(query, variables)
 

--- a/action.yaml
+++ b/action.yaml
@@ -77,7 +77,7 @@ runs:
             label: "${{ inputs.issue-label }}",
             creator: "app/github-actions",
             title: "${{ inputs.issue-title }}"
-          }
+          };
           const result = await github.graphql(query, variables);
 
           // If no issue is open, create a new issue,

--- a/action.yaml
+++ b/action.yaml
@@ -8,7 +8,8 @@ inputs:
     required: true
   issue-title:
     description: >-
-      Title of issue being created or updated
+      Title of issue being created or updated. Can be a parametrized string, in which case
+      a new issue will be opened for all variations.
     required: false
     default: "⚠️ Nightly upstream-dev CI failed ⚠️"
   issue-label:

--- a/action.yaml
+++ b/action.yaml
@@ -58,14 +58,12 @@ runs:
 
           // Run GraphQL query against GitHub API to find the most recent open issue used for reporting failures
           const query = `query($owner:String!, $name:String!, $creator:String!, $title:String!, $label:String!){
-            repository(owner: $owner, name: $name) {
-              issues(first: 1, states: OPEN, filterBy: {createdBy: $creator, labels: [$label], title: $title}, orderBy: {field: CREATED_AT, direction: DESC}) {
-                edges {
-                  node {
-                    body
-                    id
-                    number
-                  }
+            search(query: "repo:$owner/$name author:$creator label:$label in:title $title", type:ISSUE, first: 1) {
+              edges {
+                node {
+                  body
+                  id
+                  number
                 }
               }
             }
@@ -76,7 +74,7 @@ runs:
             name: context.repo.repo,
             label: "${{ inputs.issue-label }}",
             title: "${{ inputs.issue-title }}",
-            creator: "github-actions[bot]"
+            creator: "app/github-actions"
           }
           const result = await github.graphql(query, variables)
 

--- a/action.yaml
+++ b/action.yaml
@@ -67,7 +67,7 @@ runs:
 
           // Run GraphQL query against GitHub API to find the most recent open issue used for reporting failures
           const query = `query {
-            search(query: ${query_string}, type:ISSUE, first: 1) {
+            search(query: "${query_string}", type:ISSUE, first: 1) {
               edges {
                 node {
                   ... on Issue {

--- a/action.yaml
+++ b/action.yaml
@@ -58,15 +58,13 @@ runs:
 
           // Run GraphQL query against GitHub API to find the most recent open issue used for reporting failures
           const query = `query($value:String!) {
-            query {
-              search(query: $value, type:ISSUE, first: 1) {
-                edges {
-                  node {
-                    ... on Issue {
-                      body
-                      id
-                      number
-                    }
+            search(query: $value, type:ISSUE, first: 1) {
+              edges {
+                node {
+                  ... on Issue {
+                    body
+                    id
+                    number
                   }
                 }
               }

--- a/action.yaml
+++ b/action.yaml
@@ -63,7 +63,7 @@ runs:
             creator: "app/github-actions",
             title: "${{ inputs.issue-title }}"
           };
-          const query_string = `repo:${variables.owner}/${variables.name} author:${variables.creator} label:${variables.label} in:title ${variables.title}`;
+          const query_string = `repo:${variables.owner}/${variables.name} author:${variables.creator} label:${variables.label} is:open in:title ${variables.title}`;
 
           // Run GraphQL query against GitHub API to find the most recent open issue used for reporting failures
           const query = `query {

--- a/action.yaml
+++ b/action.yaml
@@ -57,7 +57,7 @@ runs:
           const issue_body = `[Workflow Run URL](${workflow_url})\n${pytest_logs}`
 
           // Run GraphQL query against GitHub API to find the most recent open issue used for reporting failures
-          const query = `query($owner:String!, $name:String!, $creator:String!, $label:String!){
+          const query = `query($owner:String!, $name:String!, $creator:String!, $title:String!, $label:String!){
             repository(owner: $owner, name: $name) {
               issues(first: 1, states: OPEN, filterBy: {createdBy: $creator, labels: [$label], title: $title}, orderBy: {field: CREATED_AT, direction: DESC}) {
                 edges {

--- a/action.yaml
+++ b/action.yaml
@@ -78,7 +78,7 @@ runs:
           const creator = "app/github-actions";
 
           const variables = {
-            query: `repo:${owner}/${name} author:${creator} label:${label} is:open in:title ${title}`;
+            query: `repo:${owner}/${name} author:${creator} label:${label} is:open in:title ${title}`
           }
           const result = await github.graphql(query, variables)
 

--- a/action.yaml
+++ b/action.yaml
@@ -59,7 +59,7 @@ runs:
           // Run GraphQL query against GitHub API to find the most recent open issue used for reporting failures
           const query = `query($owner:String!, $name:String!, $creator:String!, $label:String!){
             repository(owner: $owner, name: $name) {
-              issues(first: 1, states: OPEN, filterBy: {createdBy: $creator, labels: [$label]}, orderBy: {field: CREATED_AT, direction: DESC}) {
+              issues(first: 1, states: OPEN, filterBy: {createdBy: $creator, labels: [$label], title: $title}, orderBy: {field: CREATED_AT, direction: DESC}) {
                 edges {
                   node {
                     body

--- a/action.yaml
+++ b/action.yaml
@@ -58,7 +58,7 @@ runs:
 
           // Run GraphQL query against GitHub API to find the most recent open issue used for reporting failures
           const query = `query($owner:String!, $name:String!, $creator:String!, $title:String!, $label:String!){
-            const query = `repo:$owner/$name author:$creator label:$label is:open in:title $title`;
+            const query = `repo:${owner}/${name} author:${creator} label:${label} is:open in:title ${title}`;
 
             {
               search(query: "repo:$owner/$name author:$creator label:$label in:title is:open $title", type:ISSUE, first: 1) {

--- a/action.yaml
+++ b/action.yaml
@@ -52,10 +52,10 @@ runs:
         script: |
           const fs = require('fs');
           const pytest_logs = fs.readFileSync('pytest-logs.txt', 'utf8');
-          const title = "${{ inputs.issue-title }}"
-          const assignees = "${{inputs.assignees}}".split(",")
-          const workflow_url = `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
-          const issue_body = `[Workflow Run URL](${workflow_url})\n${pytest_logs}`
+          const title = "${{ inputs.issue-title }}";
+          const assignees = "${{inputs.assignees}}".split(",");
+          const workflow_url = `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+          const issue_body = `[Workflow Run URL](${workflow_url})\n${pytest_logs}`;
 
           // Run GraphQL query against GitHub API to find the most recent open issue used for reporting failures
           const query = `query($value:String!) {

--- a/action.yaml
+++ b/action.yaml
@@ -75,7 +75,7 @@ runs:
           const variables = {
             owner: context.repo.owner,
             name: context.repo.repo,
-            label: "${{ inputs.issue-label }}";
+            label: "${{ inputs.issue-label }}",
             creator: "app/github-actions",
             title: "${{ inputs.issue-title }}"
           }

--- a/action.yaml
+++ b/action.yaml
@@ -74,8 +74,7 @@ runs:
           }`;
           const owner = context.repo.owner;
           const name = context.repo.repo;
-          const label = "${{ input.issue-label }}";
-          const title = "${{ input.issue-title }}";
+          const label = "${{ inputs.issue-label }}";
           const creator = "app/github-actions";
 
           const variables = {

--- a/action.yaml
+++ b/action.yaml
@@ -56,9 +56,18 @@ runs:
           const workflow_url = `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
           const issue_body = `[Workflow Run URL](${workflow_url})\n${pytest_logs}`;
 
+          const variables = {
+            owner: context.repo.owner,
+            name: context.repo.repo,
+            label: "${{ inputs.issue-label }}",
+            creator: "app/github-actions",
+            title: "${{ inputs.issue-title }}"
+          };
+          const query_string = `repo:${variables.owner}/${variables.name} author:${variables.creator} label:${variables.label} in:title ${variables.title}`;
+
           // Run GraphQL query against GitHub API to find the most recent open issue used for reporting failures
-          const query = `query($owner:String!, $name:String!, $creator:String!, $label:String!, $title:String!) {
-            search(query: "repo:$owner/$name author:$creator label:$label is:open in:title $title", type:ISSUE, first: 1) {
+          const query = `query {
+            search(query: ${query_string}, type:ISSUE, first: 1) {
               edges {
                 node {
                   ... on Issue {
@@ -71,14 +80,7 @@ runs:
             }
           }`;
 
-          const variables = {
-            owner: context.repo.owner,
-            name: context.repo.repo,
-            label: "${{ inputs.issue-label }}",
-            creator: "app/github-actions",
-            title: "${{ inputs.issue-title }}"
-          };
-          const result = await github.graphql(query, variables);
+          const result = await github.graphql(query);
 
           // If no issue is open, create a new issue,
           // else update the body of the existing issue.

--- a/action.yaml
+++ b/action.yaml
@@ -58,12 +58,18 @@ runs:
 
           // Run GraphQL query against GitHub API to find the most recent open issue used for reporting failures
           const query = `query($owner:String!, $name:String!, $creator:String!, $title:String!, $label:String!){
-            search(query: "repo:$owner/$name author:$creator label:$label in:title $title", type:ISSUE, first: 1) {
-              edges {
-                node {
-                  body
-                  id
-                  number
+            const query = `repo:$owner/$name author:$creator label:$label is:open in:title $title`;
+
+            {
+              search(query: "repo:$owner/$name author:$creator label:$label in:title is:open $title", type:ISSUE, first: 1) {
+                edges {
+                  node {
+                    ... on Issue {
+                      body
+                      id
+                      number
+                    }
+                  }
                 }
               }
             }

--- a/action.yaml
+++ b/action.yaml
@@ -60,8 +60,8 @@ runs:
           const query = `query($owner:String!, $name:String!, $creator:String!, $title:String!, $label:String!){
             const query = `repo:${owner}/${name} author:${creator} label:${label} is:open in:title ${title}`;
 
-            {
-              search(query: "repo:$owner/$name author:$creator label:$label in:title is:open $title", type:ISSUE, first: 1) {
+            query {
+              search(query: $query, type:ISSUE, first: 1) {
                 edges {
                   node {
                     ... on Issue {

--- a/action.yaml
+++ b/action.yaml
@@ -58,8 +58,6 @@ runs:
 
           // Run GraphQL query against GitHub API to find the most recent open issue used for reporting failures
           const query = `query($owner:String!, $name:String!, $creator:String!, $title:String!, $label:String!){
-            const query = `repo:${owner}/${name} author:${creator} label:${label} is:open in:title ${title}`;
-
             query {
               search(query: $query, type:ISSUE, first: 1) {
                 edges {
@@ -74,13 +72,14 @@ runs:
               }
             }
           }`;
+          const owner = context.repo.owner;
+          const name = context.repo.repo;
+          const label = "${{ input.issue-label }}";
+          const title = "${{ input.issue-title }}";
+          const creator = "app/github-actions";
 
           const variables = {
-            owner: context.repo.owner,
-            name: context.repo.repo,
-            label: "${{ inputs.issue-label }}",
-            title: "${{ inputs.issue-title }}",
-            creator: "app/github-actions"
+            query: `repo:${owner}/${name} author:${creator} label:${label} is:open in:title ${title}`;
           }
           const result = await github.graphql(query, variables)
 


### PR DESCRIPTION
- [x] closes #34, closes #35

This changes the query to use the `search` connection, which allows querying for issue titles. As a consequence, this allows parametrizing the issue title:

``` yaml
    strategy:
      matrix:
        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
...
    steps:
...
      - name: generate the report
        if: failure()
        uses: keewis/issue-from-pytest-log@query-by-title
        with:
          log-path: pytest-log.jsonl
          issue-title: "CI: ${{matrix.os}} failed"
```

For examples, see keewis/reportlog-test#11, keewis/reportlog-test#12, and keewis/reportlog-test#13.

cc @andersy005