### PR TITLE
Pinned actions versions and add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,4 +15,4 @@ updates:
         update-types:
           - "*"
     cooldown:
-      default-days: 7
+      default-days: 14

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: "quarterly"
+    groups:
+      actions:
+        patterns:
+          - "action.yaml"
+          - "ci.yaml"
+        update-types:
+          - patch
+          - minor
+          - major
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,6 @@ updates:
           - "action.yaml"
           - "ci.yaml"
         update-types:
-          - patch
-          - minor
-          - major
+          - "*"
     cooldown:
       default-days: 7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,9 +15,9 @@ jobs:
 
     steps:
       - name: clone the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.2
       - name: setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: upgrade pip

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ubuntu-latest]
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: clone the repository

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,24 +3,24 @@ ci:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
 
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 25.1.0
+    rev: 26.1.0
     hooks:
       - id: black
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.2
+    rev: v0.15.0
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: ["--fix", "--show-fixes"]
 
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: v3.6.2
+    rev: v3.8.1
     hooks:
       - id: prettier
         args: ["--cache-location=.prettier_cache/cache"]

--- a/action.yaml
+++ b/action.yaml
@@ -46,7 +46,7 @@ runs:
       run: |
         python $GITHUB_ACTION_PATH/parse_logs.py ${{ inputs.log-path }}
     - name: create the issue
-      uses: actions/github-script@v7
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
       with:
         github-token: ${{ github.token }}
         script: |

--- a/parse_logs.py
+++ b/parse_logs.py
@@ -149,8 +149,7 @@ def format_summary(report):
 
 
 def format_report(summaries, py_version):
-    template = textwrap.dedent(
-        """\
+    template = textwrap.dedent("""\
         <details><summary>Python {py_version} Test Summary</summary>
 
         ```
@@ -158,8 +157,7 @@ def format_report(summaries, py_version):
         ```
 
         </details>
-        """
-    )
+        """)
     # can't use f-strings because that would format *before* the dedenting
     message = template.format(summaries="\n".join(summaries), py_version=py_version)
     return message
@@ -228,8 +226,7 @@ def compressed_report(reports, max_chars, **formatter_kwargs):
 
 
 def format_collection_error(error, **formatter_kwargs):
-    return textwrap.dedent(
-        """\
+    return textwrap.dedent("""\
         <details><summary>Python {py_version} Test Summary</summary>
 
         {name} failed:
@@ -238,8 +235,7 @@ def format_collection_error(error, **formatter_kwargs):
         ```
 
         </details>
-        """
-    ).format(py_version=py_version, name=error.name, traceback=error.repr_)
+        """).format(py_version=py_version, name=error.name, traceback=error.repr_)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #61 

### Changes

- Pins Actions version to their respective commit hashes according to their versions
- Adds a Dependabot configuration to keep this commit hashes up-to-date (quarterly scheduled)
- Adds a Python 3.14 build to CI
- Updates and re-runs `pre-commit` hooks

### Discussion

The action relies on `pytest` and `more-itertools`. These could also be pinned according to their hashes if we were to use `pip-tools` (and also updated automatically by Dependabot). I can quickly add this on if people would like.