### PR TITLE
switch to using `uv`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,14 @@ updates:
           - "ci.yaml"
     cooldown:
       default-days: 14
+
+  - package-ecosystem: uv
+    directory: /
+    schedule:
+      interval: "quarterly"
+    groups:
+      actions:
+        patterns:
+          - "parse_log.py.lock"
+    cooldown:
+      default-days: 14

--- a/action.yaml
+++ b/action.yaml
@@ -37,10 +37,14 @@ runs:
         python-version: "3.13"
     - name: setup the environment
       shell: bash
+      env:
+        UV_PROJECT: ${{ github.action_path }}
       run: |
         uv sync
     - name: produce the issue body
       shell: bash
+      env:
+        UV_PROJECT: ${{ github.action_path }}
       run: |
         uv run --frozen python $GITHUB_ACTION_PATH/parse_logs.py ${{ inputs.log-path }}
     - name: create the issue

--- a/action.yaml
+++ b/action.yaml
@@ -36,8 +36,12 @@ runs:
       with:
         python-version: "3.13"
         working-directory: ${{ github.action_path }}
-        activate-environment: "true"
         enable-cache: "false"
+    - name: setup environment
+      shell: bash
+      env:
+        UV_PROJECT: ${{ github.action_path }}
+      run: uv sync
     - name: produce the issue body
       shell: bash
       env:

--- a/action.yaml
+++ b/action.yaml
@@ -41,7 +41,7 @@ runs:
         uv sync
     - name: produce the issue body
       run: |
-        uv run python $GITHUB_ACTION_PATH/parse_logs.py ${{ inputs.log-path }}
+        uv run --frozen python $GITHUB_ACTION_PATH/parse_logs.py ${{ inputs.log-path }}
     - name: create the issue
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       with:

--- a/action.yaml
+++ b/action.yaml
@@ -32,21 +32,18 @@ runs:
   using: composite
   # TODO: learn enough javascript / node.js to write the reportlog parsing
   steps:
-    - name: print environment information
-      shell: bash -l {0}
+    - name: setup uv
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
+      with:
+        python-version: "3.13"
+    - name: setup the environment
       run: |
-        python --version
-        python -m pip list
-    - name: install dependencies
-      shell: bash -l {0}
-      run: |
-        python -m pip install pytest more-itertools
+        uv sync
     - name: produce the issue body
-      shell: bash -l {0}
       run: |
-        python $GITHUB_ACTION_PATH/parse_logs.py ${{ inputs.log-path }}
+        uv run python $GITHUB_ACTION_PATH/parse_logs.py ${{ inputs.log-path }}
     - name: create the issue
-      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       with:
         github-token: ${{ github.token }}
         script: |

--- a/action.yaml
+++ b/action.yaml
@@ -37,6 +37,7 @@ runs:
         python-version: "3.13"
         working-directory: ${{ github.action_path }}
         activate-environment: "true"
+        enable-cache: "false"
     - name: produce the issue body
       shell: bash
       env:

--- a/action.yaml
+++ b/action.yaml
@@ -47,7 +47,7 @@ runs:
       env:
         UV_PROJECT: ${{ github.action_path }}
       run: |
-        uv run --frozen python $GITHUB_ACTION_PATH/parse_logs.py ${{ inputs.log-path }}
+        uv run --frozen $GITHUB_ACTION_PATH/parse_logs.py ${{ inputs.log-path }}
     - name: create the issue
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       with:

--- a/action.yaml
+++ b/action.yaml
@@ -36,9 +36,11 @@ runs:
       with:
         python-version: "3.13"
     - name: setup the environment
+      shell: bash
       run: |
         uv sync
     - name: produce the issue body
+      shell: bash
       run: |
         uv run --frozen python $GITHUB_ACTION_PATH/parse_logs.py ${{ inputs.log-path }}
     - name: create the issue

--- a/action.yaml
+++ b/action.yaml
@@ -35,12 +35,7 @@ runs:
       uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
       with:
         python-version: "3.13"
-    - name: setup the environment
-      shell: bash
-      env:
-        UV_PROJECT: ${{ github.action_path }}
-      run: |
-        uv sync
+        working-directory: ${{ github.action_path }}
     - name: produce the issue body
       shell: bash
       env:

--- a/action.yaml
+++ b/action.yaml
@@ -30,7 +30,6 @@ branding:
 
 runs:
   using: composite
-  # TODO: learn enough javascript / node.js to write the reportlog parsing
   steps:
     - name: setup uv
       uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0

--- a/action.yaml
+++ b/action.yaml
@@ -36,6 +36,7 @@ runs:
       with:
         python-version: "3.13"
         working-directory: ${{ github.action_path }}
+        activate-environment: "true"
     - name: produce the issue body
       shell: bash
       env:

--- a/action.yaml
+++ b/action.yaml
@@ -37,11 +37,6 @@ runs:
         python-version: "3.13"
         working-directory: ${{ github.action_path }}
         enable-cache: "false"
-    - name: setup environment
-      shell: bash
-      env:
-        UV_PROJECT: ${{ github.action_path }}
-      run: uv sync
     - name: produce the issue body
       shell: bash
       env:

--- a/parse_logs.py
+++ b/parse_logs.py
@@ -1,3 +1,14 @@
+#!/usr/bin/env python
+# /// script
+# dependencies = [
+#     "pytest",
+#     "more-itertools",
+# ]
+# requires-python = ">=3.12"
+#
+# [tool.uv]
+# exclude-newer = "1 week"
+# ///
 # type: ignore
 import argparse
 import functools

--- a/parse_logs.py.lock
+++ b/parse_logs.py.lock
@@ -2,6 +2,16 @@ version = 1
 revision = 3
 requires-python = ">=3.12"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P1W"
+
+[manifest]
+requirements = [
+    { name = "more-itertools" },
+    { name = "pytest" },
+]
+
 [[package]]
 name = "colorama"
 version = "0.4.6"
@@ -18,20 +28,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
-]
-
-[[package]]
-name = "issue-from-pytest-log"
-source = { virtual = "." }
-dependencies = [
-    { name = "more-itertools" },
-    { name = "pytest" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "more-itertools" },
-    { name = "pytest" },
 ]
 
 [[package]]
@@ -72,7 +68,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.1.1"
+version = "9.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -81,7 +77,7 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/0e/b5858858d74958632c49b72cb25a3976ff9f632397626715be71c89d3971/pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c", size = 1634181, upload-time = "2026-06-13T18:52:45.983Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32", size = 386453, upload-time = "2026-06-13T18:52:44.045Z" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,13 @@
+[project]
+name = "issue-from-pytest-log"
+license = "MIT"
+dependencies = [
+  "pytest",
+  "more-itertools",
+]
+requires-python = ">=3.12"
+dynamic = ["version"]
+
 [tool.ruff]
 target-version = "py310"
 builtins = ["ellipsis"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.ruff]
-target-version = "py312"
+target-version = "py313"
 builtins = ["ellipsis"]
 exclude = [
   ".git",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,9 @@ dependencies = [
 requires-python = ">=3.12"
 dynamic = ["version"]
 
+[tool.uv]
+exclude-newer = "1 week"
+
 [tool.ruff]
 target-version = "py312"
 builtins = ["ellipsis"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.12"
 dynamic = ["version"]
 
 [tool.ruff]
-target-version = "py310"
+target-version = "py312"
 builtins = ["ellipsis"]
 exclude = [
   ".git",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,16 +1,3 @@
-[project]
-name = "issue-from-pytest-log"
-license = "MIT"
-dependencies = [
-  "pytest",
-  "more-itertools",
-]
-requires-python = ">=3.12"
-dynamic = ["version"]
-
-[tool.uv]
-exclude-newer = "1 week"
-
 [tool.ruff]
 target-version = "py312"
 builtins = ["ellipsis"]

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,87 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "issue-from-pytest-log"
+source = { virtual = "." }
+dependencies = [
+    { name = "more-itertools" },
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "more-itertools" },
+    { name = "pytest" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "11.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/1d/f4da6f02cdffe04d6362210b807146a26044c88d839208aec273bb0d9184/more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d", size = 145772, upload-time = "2026-05-22T14:14:29.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192", size = 72226, upload-time = "2026-05-22T14:14:28.824Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]


### PR DESCRIPTION
We're currently pulling in unpinned versions of the dependencies (`pytest` and `more-itertools`, which each depend on other projects).

As requested in #62, this changes the action to use a lock file (`uv.lock` currently, could become `pylock.toml` in the future).

~(I'll setup CI that checks the action in a bit)~ Edit: actually, that doesn't really work because it would have to mutate this repo, which we don't want. I have [reportlog-test](https://github.com/keewis/reportlog-test) that I can use to trigger the action, though.

cc @Zeitsperre