### PR TITLE
support missing log files

### DIFF
--- a/format_issue_body.py
+++ b/format_issue_body.py
@@ -149,7 +149,8 @@ def format_summary(report):
 
 
 def format_report(summaries, py_version):
-    template = textwrap.dedent("""\
+    template = textwrap.dedent(
+        """\
         <details><summary>Python {py_version} Test Summary</summary>
 
         ```
@@ -157,7 +158,8 @@ def format_report(summaries, py_version):
         ```
 
         </details>
-        """)
+        """,
+    )
     # can't use f-strings because that would format *before* the dedenting
     message = template.format(summaries="\n".join(summaries), py_version=py_version)
     return message

--- a/format_issue_body.py
+++ b/format_issue_body.py
@@ -280,7 +280,13 @@ if __name__ == "__main__":
             """\
             Something went wrong.
 
-            However, the log file does not exist so there are no additional details.
+            However, the log file at
+
+            ```
+            {path}
+            ```
+
+            does not exist so there are no additional details.
             """,
         )
     else:

--- a/format_issue_body.py
+++ b/format_issue_body.py
@@ -279,7 +279,7 @@ if __name__ == "__main__":
         lines = path.read_text().splitlines()
     except FileNotFoundError:
         message = textwrap.dedent(
-            """\
+            f"""\
             Something went wrong.
 
             However, the log file at

--- a/format_issue_body.py
+++ b/format_issue_body.py
@@ -274,7 +274,7 @@ if __name__ == "__main__":
     path = args["log-file"]
 
     try:
-        lines = args["log-file"].read_text().splitlines()
+        lines = path.read_text().splitlines()
     except FileNotFoundError:
         message = textwrap.dedent(
             """\

--- a/format_issue_body.py
+++ b/format_issue_body.py
@@ -295,7 +295,7 @@ if __name__ == "__main__":
         message = format_message(lines)
 
     workflow_link = f"[Workflow Run URL]({args['workflow-url']})"
-    body = "\n".join([workflow_link, message])
+    body = "\n".join([workflow_link, "", message])
 
     output_file = args["issue-body"]
     print(f"Writing output file to: {output_file.absolute()}")

--- a/format_issue_body.py
+++ b/format_issue_body.py
@@ -238,20 +238,7 @@ def format_collection_error(error, **formatter_kwargs):
         """).format(py_version=py_version, name=error.name, traceback=error.repr_)
 
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument("log-file", type=pathlib.Path)
-    parser.add_argument("workflow-url", type=str)
-    parser.add_argument(
-        "issue-body", type=pathlib.Path, default="issue-body.md", nargs="?"
-    )
-    args = vars(parser.parse_args())
-
-    py_version = ".".join(str(_) for _ in sys.version_info[:2])
-
-    print("Parsing logs ...")
-
-    lines = args["log-file"].read_text().splitlines()
+def format_message(lines):
     parsed_lines = [json.loads(line) for line in lines]
     reports = [
         parse_record(data)
@@ -267,6 +254,37 @@ if __name__ == "__main__":
         message = compressed_report(
             preformatted, max_chars=65535, py_version=py_version
         )
+
+    return message
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("log-file", type=pathlib.Path)
+    parser.add_argument("workflow-url", type=str)
+    parser.add_argument(
+        "issue-body", type=pathlib.Path, default="issue-body.md", nargs="?"
+    )
+    args = vars(parser.parse_args())
+
+    py_version = ".".join(str(_) for _ in sys.version_info[:2])
+
+    print("Parsing logs ...")
+
+    path = args["log-file"]
+
+    try:
+        lines = args["log-file"].read_text().splitlines()
+    except FileNotFoundError:
+        message = textwrap.dedent(
+            """\
+            Something went wrong.
+
+            However, the log file does not exist so there are no additional details.
+            """,
+        )
+    else:
+        message = format_message(lines)
 
     workflow_link = f"[Workflow Run URL]({args['workflow-url']})"
     body = "\n".join([workflow_link, message])


### PR DESCRIPTION
- [x] closes #60

Not sure if we can do better than this if the log file is missing.

Test runs at [run](https://github.com/keewis/reportlog-test/actions/runs/28290172741) / [issue](https://github.com/keewis/reportlog-test/issues/30) (check the edit history of that issue)