### PR TITLE
maintenance on the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ How this works:
 
 To use the `issue-from-pytest-log` action in workflows, simply add a new step:
 
-> [!WARNING]
+> [!IMPORTANT]
 > The action won't run properly unless the `issues: write` permission is requested as shown below.
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -109,4 +109,5 @@ Any assignees to set on the new issue:
     assignees: user1,user2
 ```
 
-Note that assignees must have the commit bit on the repository.
+> [!IMPORTANT]
+> Note that assignees must have the commit bit on the repository.

--- a/README.md
+++ b/README.md
@@ -18,15 +18,14 @@ To use the `issue-from-pytest-log` action in workflows, simply add a new step:
 > The action won't run properly unless the `issues: write` permission is requested as shown below.
 
 ```yaml
+permissions: {}
+
 jobs:
   my-job:
     ...
     strategy:
       fail-fast: false
       ...
-
-    permissions:
-      issues: write
 
     ...
 
@@ -45,15 +44,35 @@ jobs:
     - run: |
         pytest --report-log pytest-log.jsonl
 
-    ...
+    - uses: actions/upload-artifact@...
+      with:
+        name: log file
+        path: pytest-log-jsonl
+
+  create-issue:
+    needs: my-job
+    runs-on: ubuntu-latest
+
+    permissions:
+      issues: write
+
+    steps:
+    - uses: actions/download-artifact@...
+      with:
+        name: log file
+        path: logs/
 
     - uses: scientific-python/issue-from-pytest-log-action@f94477e45ef40e4403d7585ba639a9a3bcc53d43  # v1.3.0
       if: |
         failure()
         && ...
       with:
-        log-path: pytest-log.jsonl
+        log-path: logs/pytest-log.jsonl
 ```
+
+> [!TIP]
+> The above shows how to split the execution of tests from a task with elevated permissions (opening
+> / updating an issue). This is good practice to reduce the risks of supply-chain attacks.
 
 See [this repository](https://github.com/keewis/reportlog-test/issues) for example issues. For more realistic examples, see
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ required.
 
 Use `log-path` to specify where the output of `pytest-reportlog` is.
 
+> [!NOTE]
+> If the log file is missing (for example, because the workflow failed before `pytest` was run), the
+> action will still open / update, but the issue will contain no details about the exact failure.
+
 ### issue title
 
 optional. Default: `⚠️ Nightly upstream-dev CI failed ⚠️`

--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ jobs:
 ```
 
 > [!TIP]
-> The above shows how to split the execution of tests from a task with elevated
-> permissions (opening / updating an issue). This is good practice to reduce the risks of
-> supply-chain attacks.
+> In the example above, the action is in a separate job from the test run to avoid giving
+> untrusted code (typically nightly dependencies) access to a token that can modify the
+> repository. This is good practice to reduce the risk of supply-chain attacks.
 
 See [this repository](https://github.com/keewis/reportlog-test/issues) for example issues. For more realistic examples, see
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The label to set on the new issue.
 
 ### assignees
 
-optional
+optional. A comma-separated list of users.
 
 Any assignees to set on the new issue:
 
@@ -106,7 +106,7 @@ Any assignees to set on the new issue:
 - uses: scientific-python/issue-from-pytest-log-action@f94477e45ef40e4403d7585ba639a9a3bcc53d43 # v1.3.0
   with:
     log-path: pytest-log.jsonl
-    assignees: ["user1", "user2"]
+    assignees: user1,user2
 ```
 
 Note that assignees must have the commit bit on the repository.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ How this works:
 To use the `issue-from-pytest-log` action in workflows, simply add a new step:
 
 > [!IMPORTANT]
-> The action won't run properly unless the `issues: write` permission is requested as shown below.
+> The action won't run properly unless the `issues: write` permission is requested as
+> shown below.
 
 ```yaml
 permissions: {}
@@ -71,8 +72,9 @@ jobs:
 ```
 
 > [!TIP]
-> The above shows how to split the execution of tests from a task with elevated permissions (opening
-> / updating an issue). This is good practice to reduce the risks of supply-chain attacks.
+> The above shows how to split the execution of tests from a task with elevated
+> permissions (opening / updating an issue). This is good practice to reduce the risks of
+> supply-chain attacks.
 
 See [this repository](https://github.com/keewis/reportlog-test/issues) for example issues. For more realistic examples, see
 
@@ -88,8 +90,9 @@ required.
 Use `log-path` to specify where the output of `pytest-reportlog` is.
 
 > [!NOTE]
-> If the log file is missing (for example, because the workflow failed before `pytest` was run), the
-> action will still open / update, but the issue will contain no details about the exact failure.
+> If the log file is missing (for example, because the workflow failed before `pytest` was
+> run), the action will still open / update, but the issue will contain no details about
+> the exact failure.
 
 ### issue title
 

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ Use `log-path` to specify where the output of `pytest-reportlog` is.
 
 > [!NOTE]
 > If the log file is missing (for example, because the workflow failed before `pytest` was
-> run), the action will still open / update, but the issue will contain no details about
-> the exact failure.
+> run), the action will still open / update, but the issue won't contain details about the
+> exact failure.
 
 ### issue title
 


### PR DESCRIPTION
A couple of parameter descriptions were unclear (`assignees`) or incomplete (`log-file`).